### PR TITLE
updating readme to new deployment pattern

### DIFF
--- a/nuke-from-orbit/README.md
+++ b/nuke-from-orbit/README.md
@@ -7,17 +7,14 @@ Sometimes you need a little more boom, so let's rain fire from the clouds... it'
 This section contains a framework for a Kubernetes-based distributed LocustIO cluster. Provided is an example of how to
 run a "real browser" based test of a looker dashboard.
 
-This guide is derived from the official GCP Locust/Kubernetes tutorial, which can be found
-[here.](https://cloud.google.com/solutions/distributed-load-testing-using-gke)
-
-The instructions below are for GCP, but this can be run on any Kubernetes cluster in any environment. At a high level
+The instructions below are for GCP, but this pattern can be run on any Kubernetes cluster in any environment with some modifications. At a high level
 the steps are:
 
 1. Build a Docker image of your locust tests
 2. Spin up a Kubernetes cluster
 3. Create the master and worker deployments, the service, and any related secrets
-4. Wire it up to a monitoring solution, like Grafana
-5. Provide ingress, secured with HTTPS and some form of authentication (IAP in this case)
+4. Provide ingress, secured with HTTPS and some form of authentication (IAP in this case)
+5. (Optional) Wire it up to a monitoring solution, like Grafana
 
 ## A note on scaling
 
@@ -37,7 +34,17 @@ on a dashboard this is equivalent to approximately 600 concurrent users.
 
 ## Prerequisites
 
-In order for https and IAP to work correctly you will need to own or have control of a registered domain. You should
+First, you will need access to GCP and have installed the [gcloud command line utility](https://cloud.google.com/sdk/install).
+
+You will need access to a unix-like system and a bash shell. OSX or Linux will work fine. Linux subsystem for Windows
+should also work, but I have not tested these instructions on Windows.
+
+You will need a working version of python 3.7. I would recommend making use of [pyenv](https://github.com/pyenv/pyenv) to manage your Python
+installations. You will also need [Pipenv](https://pipenv-fork.readthedocs.io/en/latest/) to manage the virtual environment and the required library installation.
+
+You will also need [jq](https://stedolan.github.io/jq/), a command-line JSON parsing utility.
+
+Finally, in order for https and IAP to work correctly you will need to own or have control of a registered domain. You should
 have the ability to create an A-Record from that domain's DNS.
 
 ## Before you begin
@@ -46,219 +53,171 @@ The following steps need to be completed before you begin to deploy the load tes
 one time per project - during subsequent deployments you won't need to repeat these steps (unless you delete any of the
 assets of course)
 
-Open Cloud Shell to execute the commands listed in this tutorial.
+### From the GCP Console
+
+1. Create a suitable GCP Project. I recommend creating a new unique project for the load testing tool. We don’t want to run the risk of trampling other projects you may be working on.
+2. Create a service account in your new project:
+    * Navigate to IAM-Admin -> Service Accounts, click Create Service Account at top of page.
+    * Follow the instructions to create a service account:
+    * On the second page when prompted for roles you can give it Project Editor.
+    * On the third page you do not need to grant any user access to the Service Account.
+    * Back on the main page find your new service account and under the “Actions” menu choose “Create Key”:
+        * Select JSON key and a credentials json file will be downloaded to your system.
+
+> ⚠ **WARNING: This file should be considered sensitive and should be secured appropriately.**
+
+3. Assign IAP WebApp User Permissions to yourself:
+    * Navigate to IAM-Admin -> IAM
+    * Find yourself in the list of users and accounts (i.e. the email address you want to use to log in to the tool). Click the Edit icon on the right.
+    * Click ‘Add Another Role’ and select ‘IAP-secured Web App User`
+4. Create your OAuth Consent Page:
+    * Navigate to API & Services -> Oauth Consent Screen. Create an app:
+        * Set the type to Internal (unless you need to share permissions external to your org)
+        * Enter an App Name, User Support Email and Developer Contact Information.
+    * The next page should be Scopes - do not fill in anything.
+5. Create Oauth Credentials:
+    * Navigate to API & Services -> Credentials.
+    * Click Create Credentials.
+        * Select Oauth Client Id.
+        * For Application Type, select Web Application.
+        * Add a name and click Create.
+    * You will find your Client ID and Client Secret in the upper right corner of the next page. Copy them somewhere - we’ll need them in a minute.
+    * On this same page add an Authorized Redirect URI using the following template (replace `{{CLIENT_ID}}` with your new Client ID): `https://iap.googleapis.com/v1/oauth/clientIds/{{CLIENT_ID}}:handleRedirect`
+
+### Clone The Repo
+
+In your development environment, clone the load testing repo:
+
+    $ git clone https://github.com/llooker/looker-load-testing.git
+    $ cd looker-load-testing
+
+### Install Python libraries
+
+Using `pipenv`, install the required Python libraries:
+
+    $ pipenv install --ignore-pipfile --python 3.7
+
+
+### Activate Your gcloud Service Account
+
+You will need to activate the service account using the credentials file you generated above:
+
+    $ gcloud auth activate-service-account foobar@myproject.iam.gserviceaccount.com --key-file path/to/credentials.json
+
+You will likely need to (re)initialize your gcloud profile:
+
+    $ gcloud init
+
+Follow the interactive steps to select your service account and relevant GCP Project.
 
 ### Enable APIs
 
-The Following services should be enabled in your project: Cloud Build, Kubernetes Engine, Cloud Storage
+The Following services should be enabled in your project:
 
     $ gcloud services enable \
       cloudbuild.googleapis.com \
       compute.googleapis.com \
       container.googleapis.com \
       containeranalysis.googleapis.com \
-      containerregistry.googleapis.com
+      containerregistry.googleapis.com \
+      iap.googleapis.com
 
-### Static IP and DNS
-
-Create a static IP. This will be used by our ingress controller and will allow you to set up your DNS records just
-once:
-
-    $ gcloud compute addresses create loadtest-address --global
-    $ gcloud compute addresses describe loadtest-address --global
-
-Then follow the instructions for your DNS provider to create an A-Record that maps the IP address you just created to
-the following value: `*.loadtest.[DOMAIN]` (replace [DOMAIN] with your domain name, e.g. `example.com`)
-
-### OAuth Config
-
-In order to use Identity Aware Proxy (IAP) you will need to set up OAuth:
-
-1. Follow the instructions for [Configuring the OAuth Consent
-   Screen](https://cloud.google.com/iap/docs/enabling-kubernetes-howto#oauth-configure)
-
-2. Follow the instructions for [Creating OAuth Credentials](https://cloud.google.com/iap/docs/enabling-kubernetes-howto#oauth-credentials).
-   Make a note of your client-id and client-secret
-
-### Download the code
-
-Clone this repo in a local directory on your cloud shell environment and cd to the `nuke-from-orbit` directory:
-
-        $ git clone https://github.com/JCPistell/looker-load-testing.git
-        $ cd looker-load-testing/nuke-from-orbit
 
 ## Deploy The Load Tester
 
-Open Cloud Shell to execute the commands listed in this tutorial.
+### Write your test manifest
 
-Define environment variables for the project id, region and zone you want to use for this tutorial.
-
-    $ PROJECT=$(gcloud config get-value project)
-    $ REGION=us-central1
-    $ ZONE=${REGION}-c
-    $ CLUSTER=gke-load-test
-    $ gcloud config set compute/region $REGION
-    $ gcloud config set compute/zone $ZONE
-
-1. Create GKE cluster. In this example we're using a cluster of 3 c2-standard-8 machines but you may need a different
-   setup depending on your load tests. Note the cluster version - make sure you're using >= 1.16.9.
-
-        $ gcloud container clusters create $CLUSTER \
-          --zone $ZONE \
-          --scopes "https://www.googleapis.com/auth/cloud-platform" \
-          --num-nodes "3" \
-          --machine-type "c2-standard-8" \
-          --cluster-version "1.16.9-gke.6"
-
-        $ gcloud container clusters get-credentials $CLUSTER \
-          --zone $ZONE \
-          --project $PROJECT
-
-
-2. **Very Important!** Modify the contents of `docker-image/locust-tasks/tasks.py` to suit your testing criteria
+**Very Important!** Modify the contents of `docker-image/locust-tasks/tasks.py` to suit your testing criteria
 
 > The example `tasks.py` outlines a standard dashboard rendering performance test. Near the top of the file you will
 > want to modify the `SITE` and `DASH_ID` variables to match the Looker instance you are testing and the relevant
 > dashboard id. Different testing goals will require specific test code - Locust is flexible enough to handle just about
 > any kind of test you can think of!
 
-3. Build docker image and store it in your project's container registry. Note this command assumes you are in the
-   `nuke-from-orbit` directory.
+### Set Config Parameters
 
-        $ gcloud builds submit --tag gcr.io/$PROJECT/locust-tasks:latest docker-image/.
+Navigate to the nuke-from-orbit directory and create a json file called ‘config.json’. You’ll need to add entries for the following items:
 
-4. Ensure you are using the latest version of the code and are in the repo's `nuke-from-orbit` directory - all
-  commands assume that as your working directory.
+* loadtest_name: A unique identifier for your load test
+* loadtest_dns_domain: The DNS domain/subdomain name
+* gcp_project_id: The project ID of your GCP project
+* gcp_region: The GCP region
+* gcp_zone: The GCP zone
+* gcp_oauth_client_id: The OAuth Client ID you generated earlier
+* gcp_oauth_client_secret: The OAuth Client Secret you generated earlier
+* gcp_cluster_node_count: How many nodes should be included in the load test cluster
+* gcp_cluster_machine_type: What compute instance machine type should be used? (Almost certainly a C2 type instance)
+* looker_user: The username of the Looker instance you are testing
+* looker_pass: The password of the Looker instance you are testing
 
-        $ git checkout master
-        $ git pull
-        $ cd <path to nuke-from-orbit>
+Your config may look something like this:
 
-5. Replace [PROJECT_ID] in locust-controller.yaml with the deployed endpoint and project-id respectively. Note that if
-   you haven't pulled any new updates this step may be unnecessary, but it's safe to perform every time.
+```
+{
+  "loadtest_name": "my-gke-load-test-name",
+  "loadtest_dns_domain": "loadtest.company.com",
+  "gcp_project_id": "my-gcp-project-name",
+  "gcp_region": "us-central1",
+  "gcp_zone": "us-central1-c",
+  "gcp_oauth_client_id": "abc123xyz.apps.googleusercontent.com",
+  "gcp_oauth_client_secret": "foobarbaz",
+  "gcp_cluster_node_count": 3,
+  "gcp_cluster_machine_type": "c2-standard-8",
+  "looker_user": "me@company.com",
+  "looker_pass": "abc_123_xyz"
+}
+```
 
-        $ sed -i -e "s/\[PROJECT_ID\]/$PROJECT/g" kubernetes-config/locust-controller.yaml
+> ⚠ Warning: This config contains sensitive information, so protect this file like any other credentials.
 
-   If you want to enable step-mode you can change the `LOCUST_STEP` variables from `"false"` to `"true"` in
-   `locust-controller.yaml` - note that you must do this in both the `lm-pod` and `lw-pod` Deployments.
+### Deploy!
 
-6. Replace [DOMAIN] in loadtest-cert.yaml and loadtest-ingress.yaml with your domain
-   name: (be sure to replace the placeholder with your actual domain name! - e.g. `example.com`) Note that if
-   you haven't pulled any new updates this step may be unnecessary, but it's safe to perform every time.
+1. Navigate to the project root and activate your pipenv environment:
 
-        $ sed -i -e "s/\[DOMAIN\]/<your domain name>/g" kubernetes-config/loadtest-cert.yaml
-        $ sed -i -e "s/\[DOMAIN\]/<your domain name>/g" kubernetes-config/loadtest-ingress.yaml
+    $ pipenv shell
 
-7. Deploy the managed certificate:
+2. Navigate to the nuke-from-orbit directory and kick off the deployment!
 
-        $ kubectl apply -f kubernetes-config/loadtest-cert.yaml
-
-8. Create a Kubernetes secret called `iap-secret` for your OAuth client-id and client-secret: (be sure to replace the
-   placeholders with your actual values!)
-
-        $ echo -n <your_client_id> > client_id.txt
-        $ echo -n <your_client_secret> > client_secret.txt
-        $ kubectl create secret generic iap-secret --from-file=client_id=./client_id.txt --from-file=client_secret=./client_secret.txt
-
-9. Deploy the backend config:
-
-        $ kubectl apply -f kubernetes-config/config-default.yaml
-
-10. Create a Kubernetes secret called `website-creds` that contains two entries - `username` and `password` - that tie to
-   the Looker instance you will be logging into (the instance you specified in step 2):
-
-        $ echo -n <your username> > username.txt
-        $ echo -n <your password> > pass.txt
-        $ kubectl create secret generic website-creds --from-file=username=./username.txt --from-file=password=./pass.txt
-
-11. Deploy Locust master and worker nodes:
-
-        $ kubectl apply -f kubernetes-config/locust-controller.yaml
+    $ cd nuke-from-orbit
+    $ ./loadtester setup
 
 
-### Better Monitoring and Data Retention
+> ★ Tip: The script will take around 5 minutes to complete depending on what kind of instances it’s creating. It also takes a distressingly long time for the GCP Managed Cert to provision (like… 15-20 minutes or so)
 
-While we can now load test Looker at scale the data available from locust out of the box leaves something to be desired.
-Summary metrics are available for download, but the rich time series data is not, and the charts reset on every refresh.
-We can probably do better, and fortunately Kubernetes has great support for monitoring. We will use Prometheus and
-Grafana to collect and display our load testing metrics.
+3. The final output will provide additional instructions for how to set up your DNS entry to allow for access to the
+   load tester. Set up an A Record for the wildcard domain to the specified IP address.
 
-1. Deploy Prometheus
+### Accessing the Load Tester
 
-        $ kubectl apply -f kubernetes-config/prometheus-config.yaml
-        $ kubectl apply -f kubernetes-config/prometheus-controller.yaml
+For the purposes of an example, let’s say the `load_test_dns_domain` parameter in your `config.json` was set to `my-loadtest.company.com`. Once everything has some time to bake
+you will be able to access your load tester at `https://locust.my-loadtest.company.com`. This will be where you kick off load tests. It also has some graphs and metrics available.
 
-2. Deploy Grafana
+### Scaling
 
-        $ kubectl apply -f kubernetes-config/grafana-config.yaml
-        $ kubectl apply -f kubernetes-config/grafana-controller.yaml
-
-### Configure Ingress
-
-Now that we have our services configured we need to access them. This ingress config will set up a layer-7 load balancer
-based on sub-domain. We will also set up Identity Aware Proxy (IAP) to further secure our application.
-
-1. Deploy the ingress config:
-
-        $ kubectl apply -f kubernetes-config/loadtest-ingress.yaml
-
-2. Follow the instructions for [Setting up IAP
-   Access](https://cloud.google.com/iap/docs/enabling-kubernetes-howto#iap-access)
-
-At this point you will need to wait for the managed SSL certificate to provision and for the health checks to complete.
-This can take about 10-15 minutes.
-
-You can check the status of the certificate with the following command:
-
-        $ kubectl describe managedcertificate loadtest-cert
-
-When the state changes from 'Provisioning' to 'Active' your https is configured
-
-You can check the status of your load balancer ingress with the following command:
-
-        $ kubectl describe ingress loadtest-ingress
-
-In the annotations section you will be able to see the status of the health checks for each backend service. Once they
-all read 'HEALTHY' you are ready to go.
-
-Note that IAP may take a few more minutes to set up authentication, even after https and routing are configured.
-
-## Running and Monitoring a Test
-
-
-The locust interface is now available at `https://locust.loadtest.[DOMAIN]`. The Locust master web interface enables you to execute the load testing tasks against the
-system under test.
-
-To begin, specify the total number of users to simulate and a rate at which each user should be spawned. Next, click
-Start swarming to begin the simulation. To stop the simulation, click **Stop** and the test will terminate. The
-aggregated results can be downloaded into a spreadsheet. Note that the Host parameter (by default set to 'dashboard' in the example
-test) is not used when we're working with real browsers - it's used for standard API-based load tests.
-
-[Optional] Scaling clients Scaling up the number of simulated users will require an increase in the number of Locust
+Scaling up the number of simulated users will require an increase in the number of Locust
 worker pods. To increase the number of pods deployed by the deployment, Kubernetes offers the ability to resize
 deployments without redeploying them. For example, the following command scales the pool of Locust worker pods to 20:
 
         $ kubectl scale deployment/lw-pod --replicas=20
 
+### Monitoring
 
-### Grafana
-Grafana can be accessed at `https://grafana.loadtest.[DOMAIN]`. A dashboard called 'Locust' is preconfigured to connect to your Locust metrics. You can find it by navigating to Dashboards ->
-Manage. Kick off a load test from the Locust interface and enjoy your improved metrics dashboard!
-
-### Prometheus
-Prometheus can be accessed at `https://prometheus.loadtest.[DOMAIN]`. You can use [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) and the API to write queries
-against the time series data and extract it.
+While we can now load test Looker at scale, testing without monitoring is like shooting in the dark. While the locust UI
+provides some good real-time monitoring to truly make use of the data you collect I would suggest integrating the locust
+metrics with your internal Looker and other infrastructure monitoring. Keeping with the example DNS from above the load
+tester makes the Locust metrics available at `https://locust-metrics.myloadtest.company.com/metrics`. The metrics are
+presented in Prometheus format and should be ingestable by any modern monitoring tool.
 
 ## Cleaning up
 
-Once you are done load testing and exporting data you can tear down your cluster to avoid additional costs.
+Once you are done load testing and exporting data you can tear down your cluster to avoid additional costs. From the
+nuke-from-orbit directory:
 
-    $ gcloud container clusters delete $CLUSTER --zone $ZONE
+    $ ./loadtester teardown
 
-Note that this leaves your Static IP and OAuth configurations intact and ready to use for the next test. If you so
-choose you can delete them too, but you'll need to recreate them the next time you load test and update your DNS to use
-your new IP address.
+You will likely want to clean up your DNS entry as well.
 
+To kick off another test simply rerun the `./loadtester setup` command and you're back in business!
 
 ## Additional Reading
 

--- a/nuke-from-orbit/README.md
+++ b/nuke-from-orbit/README.md
@@ -138,17 +138,17 @@ The Following services should be enabled in your project:
 
 Navigate to the nuke-from-orbit directory and create a json file called ‘config.json’. You’ll need to add entries for the following items:
 
-* loadtest_name: A unique identifier for your load test
-* loadtest_dns_domain: The DNS domain/subdomain name
-* gcp_project_id: The project ID of your GCP project
-* gcp_region: The GCP region
-* gcp_zone: The GCP zone
-* gcp_oauth_client_id: The OAuth Client ID you generated earlier
-* gcp_oauth_client_secret: The OAuth Client Secret you generated earlier
-* gcp_cluster_node_count: How many nodes should be included in the load test cluster
-* gcp_cluster_machine_type: What compute instance machine type should be used? (Almost certainly a C2 type instance)
-* looker_user: The username of the Looker instance you are testing
-* looker_pass: The password of the Looker instance you are testing
+* **loadtest_name**: A unique identifier for your load test
+* **loadtest_dns_domain**: The DNS domain/subdomain name
+* **gcp_project_id**: The project ID of your GCP project
+* **gcp_region**: The GCP region
+* **gcp_zone**: The GCP zone
+* **gcp_oauth_client_id**: The OAuth Client ID you generated earlier
+* **gcp_oauth_client_secret**: The OAuth Client Secret you generated earlier
+* **gcp_cluster_node_count**: How many nodes should be included in the load test cluster
+* **gcp_cluster_machine_type**: What compute instance machine type should be used? (Almost certainly a C2 type instance)
+* **looker_user**: The username of the Looker instance you are testing
+* **looker_pass**: The password of the Looker instance you are testing
 
 Your config may look something like this:
 
@@ -172,11 +172,11 @@ Your config may look something like this:
 
 ### Deploy!
 
-1. Navigate to the project root and activate your pipenv environment:
+Navigate to the project root and activate your pipenv environment:
 
     $ pipenv shell
 
-2. Navigate to the nuke-from-orbit directory and kick off the deployment!
+Navigate to the nuke-from-orbit directory and kick off the deployment!
 
     $ cd nuke-from-orbit
     $ ./loadtester setup


### PR DESCRIPTION
Since I've gotten several requests from customers to access the google-doc instructions I've prioritized updating the readme to match the new deployment process. This is suitable for public consumption - in addition I've flagged the google-doc instructions as internal only.