### PR TITLE
improvements to the locust deployment template

### DIFF
--- a/nuke-from-orbit/kubernetes-config/templates/locust-controller.yaml
+++ b/nuke-from-orbit/kubernetes-config/templates/locust-controller.yaml
@@ -57,17 +57,31 @@ spec:
             - name: TARGET_HOST
               value: dashboard
             - name: LOCUST_STEP
-              value: "true"
+              value: "{{loadtest_step_load}}"
             - name: USERNAME
               valueFrom:
                 secretKeyRef:
                   name: website-creds
                   key: username
+                  optional: true
             - name: PASS
               valueFrom:
                 secretKeyRef:
                   name: website-creds
                   key: password
+                  optional: true
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: api-creds
+                  key: client_id
+                  optional: true
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-creds
+                  key: client_secret
+                  optional: true
           ports:
             - name: loc-master-web
               containerPort: 8089
@@ -113,17 +127,31 @@ spec:
             - name: TARGET_HOST
               value: dashboard
             - name: LOCUST_STEP
-              value: "true"
+              value: "{{loadtest_step_load}}"
             - name: USERNAME
               valueFrom:
                 secretKeyRef:
                   name: website-creds
                   key: username
+                  optional: true
             - name: PASS
               valueFrom:
                 secretKeyRef:
                   name: website-creds
                   key: password
+                  optional: true
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: api-creds
+                  key: client_id
+                  optional: true
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: api-creds
+                  key: client_secret
+                  optional: true
 ---
 kind: Service
 apiVersion: v1
@@ -134,7 +162,7 @@ metadata:
 spec:
   ports:
     - port: 80
-      targetPort: lexp-web
+      targetPort: loc-metrics-web
       protocol: TCP
   selector:
     app: le-pod
@@ -163,6 +191,6 @@ spec:
             - name: LOCUST_EXPORTER_URI
               value: http://lm-pod:80
           ports:
-            - name: lexp-web
+            - name: loc-metrics-web
               containerPort: 9646
               protocol: TCP

--- a/nuke-from-orbit/loadtester
+++ b/nuke-from-orbit/loadtester
@@ -144,6 +144,7 @@ set_variables() {
   gcp_project_id=$(cat $config_file | jq -r '.gcp_project_id // empty' | tr -d '[:space:]')
   loadtest_name=$(cat $config_file | jq -r '.loadtest_name // empty' | tr -d '[:space:]')
   loadtest_dns_domain=$(cat $config_file | jq -r '.loadtest_dns_domain // empty' | tr -d '[:space:]')
+  loadtest_step_load=$(cat $config_file | jq -r '.loadtest_step_load // empty' | tr -d '[:space:]')
   gcp_oauth_client_id=$(cat $config_file | jq -r '.gcp_oauth_client_id // empty' | tr -d '[:space:]')
   gcp_oauth_client_secret=$(cat $config_file | jq -r '.gcp_oauth_client_secret // empty' | tr -d '[:space:]')
   gcp_zone=$(cat $config_file | jq -r '.gcp_zone // empty' | tr -d '[:space:]')
@@ -152,6 +153,8 @@ set_variables() {
   gcp_cluster_machine_type=$(cat $config_file | jq -r '.gcp_cluster_machine_type // empty' | tr -d '[:space:]')
   looker_user=$(cat $config_file | jq -r '.looker_user // empty' | tr -d '[:space:]')
   looker_pass=$(cat $config_file | jq -r '.looker_pass // empty' | tr -d '[:space:]')
+  looker_api_client_id=$(cat $config_file | jq -r '.looker_api_client_id // empty' | tr -d '[:space:]')
+  looker_api_client_secret=$(cat $config_file | jq -r '.looker_api_client_secret // empty' | tr -d '[:space:]')
   aws_access_key=$(cat $config_file | jq -r '.aws_access_key // empty' | tr -d '[:space:]')
   aws_secret_key=$(cat $config_file | jq -r '.aws_secret_access_key // empty' | tr -d '[:space:]')
   aws_session_token=$(cat $config_file | jq -r '.aws_session_token // empty' | tr -d '[:space:]')
@@ -167,12 +170,15 @@ set_variables() {
   then
     if [[ -z $gcp_project_id ]]; then error+="gcp_project_id,"; fi
     if [[ -z $loadtest_name ]]; then error+="loadtest_name,"; fi
+    if [[ -z $loadtest_step_load ]]; then error+="loadtest_step_load,"; fi
     if [[ -z $loadtest_dns_domain ]]; then error+="loadtest_dns_domain,"; fi
     if [[ -z $gcp_zone ]]; then error+="gcp_zone,"; fi
     if [[ -z $gcp_cluster_node_count ]]; then error+="gcp_cluster_node_count,"; fi
     if [[ -z $gcp_cluster_machine_type ]]; then error+="gcp_cluster_machine_type,"; fi
     if [[ -z $looker_user ]]; then warning+="looker_user,"; fi
     if [[ -z $looker_pass ]]; then warning+="looker_pass,"; fi
+    if [[ -z $looker_api_client_id ]]; then warning+="looker_api_client_id,"; fi
+    if [[ -z $looker_api_client_secret ]]; then warning+="looker_api_client_secret,"; fi
   else
     if [[ -z $aws_access_key ]]; then error+="aws_access_key,"; fi
     if [[ -z $aws_secret_key ]]; then error+="aws_secret_key,"; fi
@@ -216,9 +222,22 @@ set_oauth_secret() {
 
 # Set the Looker username and password secret
 set_looker_secret() {
-  kubectl create secret generic website-creds \
-    --from-literal=username=$looker_user \
-    --from-literal=password=$looker_pass
+  if ! [[ -z $looker_user || -z $looker_pass ]]
+  then
+    kubectl create secret generic website-creds \
+      --from-literal=username=$looker_user \
+      --from-literal=password=$looker_pass
+  fi
+}
+
+# Set the Looker API secret
+set_looker_api_secret() {
+  if ! [[ -z $looker_api_client_id || -z $looker_api_client_secret ]]
+  then
+    kubectl create secret generic api-creds \
+      --from-literal=client_id=$looker_api_client_id \
+      --from-literal=client_secret=$looker_api_client_secret
+  fi
 }
 
 # Self-contained only: Set AWS credentials for monitoring
@@ -326,6 +345,7 @@ self_contained_setup() {
   get_kubernetes_creds
   set_oauth_secret
   set_looker_secret
+  set_looker_api_secret
   set_aws_secret
   deploy_managed_certificate
   deploy_backend_config
@@ -349,6 +369,7 @@ external_setup() {
   get_kubernetes_creds
   set_oauth_secret
   set_looker_secret
+  set_looker_api_secret
   deploy_managed_certificate
   deploy_backend_config
   deploy_locust


### PR DESCRIPTION
This PR addresses a few issues with the locust template:

1. It renames the metrics port to avoid name collision with Looker's table calc language
2. It templates step-loading to make it controllable via config
3. It adds the ability to include API keys (vital for some types of tests) as secrets that are ingested by the locust pod