### PR TITLE
Jcp change release channel

### DIFF
--- a/nuke-from-orbit/loadtester
+++ b/nuke-from-orbit/loadtester
@@ -103,7 +103,7 @@ gke_loadtest_cluster_gcloud() {
    --scopes "https://www.googleapis.com/auth/cloud-platform" \
    --num-nodes "$gcp_cluster_node_count" \
    --machine-type $gcp_cluster_machine_type \
-   --cluster-version "1.16.11-gke.5"
+   --release-channel regular
 }
 
 gke_loadtest_cluster_ip_gcloud() {

--- a/nuke-from-orbit/terraform/gke_loadtest_cluster/cluster.tf
+++ b/nuke-from-orbit/terraform/gke_loadtest_cluster/cluster.tf
@@ -6,13 +6,23 @@ provider "google" {
   version = "~> 3.31"
 }
 
+provider "google-beta" {
+  credentials = file(var.gcp_creds)
+  project = var.project
+  region = var.region
+  zone = var.zone
+  version = "~> 3.36"
+}
+
 resource "google_container_cluster" "gke_load_test" {
+  provider = google-beta
   name = var.loadtest_name
   location = var.zone
   initial_node_count = var.node_count
 
-  node_version = "1.16.11-gke.5"
-  min_master_version = "1.16.11-gke.5"
+  release_channel {
+    channel = "REGULAR"
+  }
 
   node_config {
     machine_type = var.machine_type


### PR DESCRIPTION
Hopefully this prevents any more gke version deprecation errors.

Note that release channels in terraform is a beta feature so I had to add the google-beta provider