### PR TITLE
pinning greenlet version

### DIFF
--- a/nuke-from-orbit/docker-image/realbrowserlocusts/setup.py
+++ b/nuke-from-orbit/docker-image/realbrowserlocusts/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 NAME = "realbrowserlocusts"
 VERSION = "0.4.1"
-REQUIRES = ["locustio==0.14.6", "selenium==3.141.0"]
+REQUIRES = ["greenlet==0.4.16", "locustio==0.14.6", "selenium==3.141.0"]
 
 setup(
     name=NAME,


### PR DESCRIPTION
gevent doesn't pin a specific greenlet version so, when a breaking change was released yesterday afternoon, it was pulled into NFO's container build.

This fix locks in the version of greenlet used by the container.