### PR TITLE
Adding persistence to NFO data

### DIFF
--- a/nuke_from_orbit/cli.py
+++ b/nuke_from_orbit/cli.py
@@ -12,14 +12,14 @@ def nuke():
 @nuke.command()
 @click.option("--config-file", help="Which config file to use for the setup")
 @click.option("--external", is_flag=True, help="Should external ingress be set up")
-@click.option("--persistence/--no-persistence", default=True, help="Should persistant disk setup be skipped?")
+@click.option("--persistence/--no-persistence", default=True, help="Should persistent disk setup be skipped?")
 def setup(**kwargs):
     setup_commands.main(**kwargs)
 
 
 @nuke.command()
 @click.option("--config-file", help="Which config file to use for the setup")
-@click.option("--all", is_flag=True, help="Should teardown include persistant disk")
+@click.option("--all", is_flag=True, help="Should teardown include persistent disk")
 def teardown(**kwargs):
     teardown_commands.main(**kwargs)
 

--- a/nuke_from_orbit/cli.py
+++ b/nuke_from_orbit/cli.py
@@ -12,12 +12,14 @@ def nuke():
 @nuke.command()
 @click.option("--config-file", help="Which config file to use for the setup")
 @click.option("--external", is_flag=True, help="Should external ingress be set up")
+@click.option("--skip-persistance", is_flag=True, help="Should persistant disk setup be skipped?")
 def setup(**kwargs):
     setup_commands.main(**kwargs)
 
 
 @nuke.command()
 @click.option("--config-file", help="Which config file to use for the setup")
+@click.option("--complete", is_flag=True, help="Should teardown include persistant disk")
 def teardown(**kwargs):
     teardown_commands.main(**kwargs)
 

--- a/nuke_from_orbit/cli.py
+++ b/nuke_from_orbit/cli.py
@@ -12,14 +12,14 @@ def nuke():
 @nuke.command()
 @click.option("--config-file", help="Which config file to use for the setup")
 @click.option("--external", is_flag=True, help="Should external ingress be set up")
-@click.option("--skip-persistance", is_flag=True, help="Should persistant disk setup be skipped?")
+@click.option("--persistence/--no-persistence", default=True, help="Should persistant disk setup be skipped?")
 def setup(**kwargs):
     setup_commands.main(**kwargs)
 
 
 @nuke.command()
 @click.option("--config-file", help="Which config file to use for the setup")
-@click.option("--complete", is_flag=True, help="Should teardown include persistant disk")
+@click.option("--all", is_flag=True, help="Should teardown include persistant disk")
 def teardown(**kwargs):
     teardown_commands.main(**kwargs)
 

--- a/nuke_from_orbit/commands/setup_commands.py
+++ b/nuke_from_orbit/commands/setup_commands.py
@@ -12,6 +12,10 @@ def main(**kwargs):
     # set the external boolean
     external = kwargs["external"]
 
+    # set the persistence boolean
+    persistence = kwargs["persistence"]
+    print(persistence)
+
     # setting tag to v1 for initial setup
     tag = "v1"
 
@@ -25,12 +29,14 @@ def main(**kwargs):
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(service_account_file)
 
     # multithread the gke deployment and cloud build for maximum fast
-    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         tasks = []
         tasks.append(executor.submit(nuke_utils.deploy_gke, user_config))
         tasks.append(executor.submit(nuke_utils.deploy_test_container_image, user_config))
         if external:
             tasks.append(executor.submit(nuke_utils.deploy_ip_address, user_config))
+        if persistence:
+            tasks.append(executor.submit(nuke_utils.deploy_persistent_disk, user_config))
 
         for future in concurrent.futures.as_completed(tasks):
             future.result()

--- a/nuke_from_orbit/commands/teardown_commands.py
+++ b/nuke_from_orbit/commands/teardown_commands.py
@@ -9,6 +9,8 @@ def main(**kwargs):
     config_dir = root_dir.joinpath("configs")
     sa_dir = root_dir.joinpath("credentials")
 
+    teardown_all = kwargs["all"]
+
     config_file = config_dir.joinpath(kwargs["config_file"])
 
     # get the user credentials
@@ -22,11 +24,13 @@ def main(**kwargs):
     ip = nuke_utils.get_ip_address(user_config)
 
     # multithread the teardown
-    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
         tasks = []
         tasks.append(executor.submit(nuke_utils.destroy_gke, user_config))
         if ip:
             tasks.append(executor.submit(nuke_utils.destroy_ip_address, user_config))
+        if teardown_all:
+            tasks.append(executor.submit(nuke_utils.destroy_persistent_disk, user_config))
 
         for future in concurrent.futures.as_completed(tasks):
             future.result()

--- a/nuke_from_orbit/utils/gke_cluster.py
+++ b/nuke_from_orbit/utils/gke_cluster.py
@@ -23,6 +23,62 @@ def get_compute_client(credentials=None):
     return client
 
 
+def create_zonal_disk(name, project, zone, client):
+    """Creates a persistant disk in the specified zone. This is suitable for use as
+    a persistant volume for Prometheus data. Returns an operation id that can be
+    used to track the job progress.
+    """
+
+    # https://cloud.google.com/compute/docs/reference/rest/v1/disks/get
+
+    body = {"name": name, "sizeGb": 50}
+    zonal_disk = client.disks()
+    request = zonal_disk.insert(project=project, zone=zone, body=body)
+    response = request.execute()
+
+    return response["name"]
+
+
+def fetch_zonal_disk(name, project, zone, client):
+    """Attempts to fetch a specified persistant disk. Accepts the name of the
+    disk, the project and zone. If the disk exists the name is returned.
+    """
+
+    zonal_disk = client.disks()
+    request = zonal_disk.get(project=project, zone=zone, disk=name)
+    response = request.execute()
+
+    return response
+
+
+def delete_zonal_disk(name, project, zone, client):
+    """Deletes a persistant disk in the specified zone. Returns an operation that
+    can be used to track the job progress.
+    """
+
+    # https://cloud.google.com/compute/docs/reference/rest/v1/disks/get
+
+    zonal_disk = client.disks()
+    request = zonal_disk.delete(project=project, zone=zone, disk=name)
+    response = request.execute()
+
+    return response["name"]
+
+
+def compute_zonal_task_status(task_name, project, zone, client):
+    """Accepts a compute zonal operation name and requests the status of the operation.
+    Returns a string of the job status. Possible values are 'PENDING', 'RUNNING'
+    and 'DONE'
+    """
+
+    # https://cloud.google.com/compute/docs/reference/rest/v1/globalOperations/get
+    zonal_operations = client.zoneOperations()
+    request = zonal_operations.get(project=project, zone=zone, operation=task_name)
+    response = request.execute()
+
+    return response["status"]
+
+
 def create_global_ip(name, project, client):
     """Creates a global ip address suitable for use with GKE ingress controller.
     Returns a job ID that can be used to track the status of the address creation.

--- a/nuke_from_orbit/utils/nuke_utils.py
+++ b/nuke_from_orbit/utils/nuke_utils.py
@@ -193,6 +193,68 @@ def render_kubernetes_templates(values_dict, files):
             f.write(rendered)
 
 
+def deploy_persistant_disk(user_config):
+    """Accepts a dict of validated user configs and uses them to build a GCE persistant disk.
+    First we check to see if the disk currently exists (i.e. persisted from last session) If
+    the disk does not exist it is created. This disk will be used as a persistant volume for
+    prometheus to retain data.
+    """
+
+    # set variables from user config
+    name = user_config["loadtest_name"]
+    project = user_config["gcp_project_id"]
+    zone = user_config["gcp_zone"]
+
+    # create the compute client. we're relying on the environment variable to be set for credentials
+    client = gke_cluster.get_compute_client()
+
+    try:
+        gke_cluster.fetch_zonal_disk(name, project, zone, client)
+        print(f"Found persistant disk {name}. Attaching to cluster...")
+    except HttpError:
+        print("No existing persistant disk found. Creating...")
+        disk_task = gke_cluster.create_zonal_disk(name, project, zone, client)
+
+        running = True
+        while running:
+            status = gke_cluster.compute_zonal_task_status(disk_task, project, zone, client)
+            print(f"Creating persistant disk {name}: {status}")
+            if status == "DONE":
+                running = False
+            else:
+                sleep(2)
+
+
+def destroy_persistant_disk(user_config):
+    """Accepts a dict of validated user configs and uses them to destroy a GCE persistant disk.
+    Tracks the status of the job and confirms successful deletion.
+    """
+
+    # set variables from user config
+    name = user_config["loadtest_name"]
+    project = user_config["gcp_project_id"]
+    zone = user_config["gcp_zone"]
+
+    # create the compute client. we're relying on the environment variable to be set for credentials
+    client = gke_cluster.get_compute_client()
+
+    try:
+        gke_cluster.fetch_zonal_disk(name, project, zone, client)
+        print(f"Found persistant disk {name}. Deleting...")
+        disk_task = gke_cluster.delete_zonal_disk(name, project, zone, client)
+
+        running = True
+        while running:
+            status = gke_cluster.compute_zonal_task_status(disk_task, project, zone, client)
+            print(f"Deleting persistant disk {name}: {status}")
+            if status == "DONE":
+                running = False
+            else:
+                sleep(2)
+    except HttpError:
+        print("No persistant disk exists. Moving on!")
+
+
 def deploy_ip_address(user_config):
     """Accepts a dict of validated user configs and uses them to deploy a global ip
     address that is used for the gke ingress controller (if appropriate).

--- a/nuke_from_orbit/utils/nuke_utils.py
+++ b/nuke_from_orbit/utils/nuke_utils.py
@@ -193,10 +193,10 @@ def render_kubernetes_templates(values_dict, files):
             f.write(rendered)
 
 
-def deploy_persistant_disk(user_config):
-    """Accepts a dict of validated user configs and uses them to build a GCE persistant disk.
+def deploy_persistent_disk(user_config):
+    """Accepts a dict of validated user configs and uses them to build a GCE persistent disk.
     First we check to see if the disk currently exists (i.e. persisted from last session) If
-    the disk does not exist it is created. This disk will be used as a persistant volume for
+    the disk does not exist it is created. This disk will be used as a persistent volume for
     prometheus to retain data.
     """
 
@@ -210,23 +210,23 @@ def deploy_persistant_disk(user_config):
 
     try:
         gke_cluster.fetch_zonal_disk(name, project, zone, client)
-        print(f"Found persistant disk {name}. Attaching to cluster...")
+        print(f"Found persistent disk {name}. Attaching to cluster...")
     except HttpError:
-        print("No existing persistant disk found. Creating...")
+        print("No existing persistent disk found. Creating...")
         disk_task = gke_cluster.create_zonal_disk(name, project, zone, client)
 
         running = True
         while running:
             status = gke_cluster.compute_zonal_task_status(disk_task, project, zone, client)
-            print(f"Creating persistant disk {name}: {status}")
+            print(f"Creating persistent disk {name}: {status}")
             if status == "DONE":
                 running = False
             else:
                 sleep(2)
 
 
-def destroy_persistant_disk(user_config):
-    """Accepts a dict of validated user configs and uses them to destroy a GCE persistant disk.
+def destroy_persistent_disk(user_config):
+    """Accepts a dict of validated user configs and uses them to destroy a GCE persistent disk.
     Tracks the status of the job and confirms successful deletion.
     """
 
@@ -240,19 +240,19 @@ def destroy_persistant_disk(user_config):
 
     try:
         gke_cluster.fetch_zonal_disk(name, project, zone, client)
-        print(f"Found persistant disk {name}. Deleting...")
+        print(f"Found persistent disk {name}. Deleting...")
         disk_task = gke_cluster.delete_zonal_disk(name, project, zone, client)
 
         running = True
         while running:
             status = gke_cluster.compute_zonal_task_status(disk_task, project, zone, client)
-            print(f"Deleting persistant disk {name}: {status}")
+            print(f"Deleting persistent disk {name}: {status}")
             if status == "DONE":
                 running = False
             else:
                 sleep(2)
     except HttpError:
-        print("No persistant disk exists. Moving on!")
+        print("No persistent disk exists. Moving on!")
 
 
 def deploy_ip_address(user_config):

--- a/nuke_from_orbit/utils/templates/prometheus-controller.yaml
+++ b/nuke_from_orbit/utils/templates/prometheus-controller.yaml
@@ -1,4 +1,33 @@
 ---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: loadtest-prom-persist
+spec:
+  storageClassName: "nfo_persistent_storage"
+  capacity:
+    storage: 50G
+  accessModes:
+    - ReadWriteOnce
+  claimRef:
+    namespace: default
+    name: loadtest_prom_persist
+  gcePersistentDisk:
+    pdName: {{loadtest_name}}
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: loadtest_prom_persist
+spec:
+  storageClassName: "nfo_persistent_storage"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50G
+---
 kind: Service
 apiVersion: v1
 metadata:
@@ -59,4 +88,5 @@ spec:
             name: prom-conf
 
         - name: prometheus-storage-volume
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: loadtest_prom_persist

--- a/nuke_from_orbit/utils/templates/prometheus-controller.yaml
+++ b/nuke_from_orbit/utils/templates/prometheus-controller.yaml
@@ -4,14 +4,14 @@ apiVersion: v1
 metadata:
   name: loadtest-prom-persist
 spec:
-  storageClassName: "nfo_persistent_storage"
+  storageClassName: "nfo-persistent-storage"
   capacity:
     storage: 50G
   accessModes:
     - ReadWriteOnce
   claimRef:
     namespace: default
-    name: loadtest_prom_persist
+    name: loadtest-prom-persist
   gcePersistentDisk:
     pdName: {{loadtest_name}}
     fsType: ext4
@@ -19,9 +19,9 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: loadtest_prom_persist
+  name: loadtest-prom-persist
 spec:
-  storageClassName: "nfo_persistent_storage"
+  storageClassName: "nfo-persistent-storage"
   accessModes:
     - ReadWriteOnce
   resources:
@@ -63,6 +63,9 @@ spec:
       containers:
         - name: prom-pod
           image: prom/prometheus:v2.19.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 0
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
@@ -89,4 +92,4 @@ spec:
 
         - name: prometheus-storage-volume
           persistentVolumeClaim:
-            claimName: loadtest_prom_persist
+            claimName: loadtest-prom-persist


### PR DESCRIPTION
This commit adds the ability to retain load test data in durable storage that can survive NFO instance teardowns/redeployments.

It accomplishes this by using Kubernetes Persistent Volume Claims. The volume used is a GCE disk that is provisioned separately. By default the volume is created on setup and retained on teardown - this is configurable via command line flags.