### PR TITLE
Fixing kubeconfig issue in update test command

### DIFF
--- a/nuke_from_orbit/commands/setup_commands.py
+++ b/nuke_from_orbit/commands/setup_commands.py
@@ -45,7 +45,10 @@ def main(**kwargs):
     if external:
         ip = nuke_utils.get_ip_address(user_config)
         dns = user_config["loadtest_dns_domain"]
-        ip_message = f"Cluster IP is {ip}. Please create an A Record in your DNS provider for *.{dns} that points to {ip}."
+        ip_message = (
+            f"Cluster IP is {ip}.\n"
+            f"Please create an A Record in your DNS provider for *.{dns} that points to {ip}.\n\n"
+        )
 
     # parse and render kubernetes template files
     file_list = nuke_utils.collect_kube_yaml_templates(external)
@@ -74,7 +77,7 @@ def main(**kwargs):
         f"export GOOGLE_APPLICATION_CREDENTIALS={str(service_account_file)}\n\n"
     )
     port_forward_message = (
-        "You can now use `kubectl port-forward` commands."
+        "You can now use `kubectl port-forward` commands. "
         "This will allow you to access your load test services directly. Read more here:\n"
         "https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster\n\n"
         "All services are available on port 80. Find services with `kubectl get svc`. Then forward to a desired port.\n"

--- a/nuke_from_orbit/commands/update_config_commands.py
+++ b/nuke_from_orbit/commands/update_config_commands.py
@@ -17,12 +17,12 @@ def main(**kwargs):
     service_account_file = sa_dir.joinpath(user_config["gcp_service_account_file"]).resolve()
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(service_account_file)
 
+    # set kubernetes context
+    nuke_utils.set_kubernetes_context(user_config)
+
     # parse and render kubernetes template files
     file_list = nuke_utils.collect_kube_yaml_templates()
     nuke_utils.render_kubernetes_templates(user_config, file_list)
-
-    # set kubernetes context
-    nuke_utils.set_kubernetes_context(user_config)
 
     # deploy secrets
     nuke_utils.deploy_looker_secret(user_config)

--- a/nuke_from_orbit/commands/update_test_commands.py
+++ b/nuke_from_orbit/commands/update_test_commands.py
@@ -11,9 +11,6 @@ def main(**kwargs):
     config_file = config_dir.joinpath(kwargs["config_file"])
     tag = kwargs["tag"]
 
-    # compare the provided tag with the existing tag
-    nuke_utils.compare_tags(tag)
-
     # get the user config
     user_config = nuke_utils.set_variables(config_file, tag)
 
@@ -21,15 +18,18 @@ def main(**kwargs):
     service_account_file = sa_dir.joinpath(user_config["gcp_service_account_file"]).resolve()
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(service_account_file)
 
+    # set kubernetes context
+    nuke_utils.set_kubernetes_context(user_config)
+
+    # compare the provided tag with the existing tag
+    nuke_utils.compare_tags(tag)
+
     # rebuild the test image with the new tag
     nuke_utils.deploy_test_container_image(user_config)
 
     # parse and render kubernetes template files
     file_list = nuke_utils.collect_kube_yaml_templates()
     nuke_utils.render_kubernetes_templates(user_config, file_list)
-
-    # set kubernetes context
-    nuke_utils.set_kubernetes_context(user_config)
 
     # deploy secrets
     nuke_utils.deploy_looker_secret(user_config)

--- a/nuke_from_orbit/utils/nuke_utils.py
+++ b/nuke_from_orbit/utils/nuke_utils.py
@@ -489,11 +489,8 @@ def compare_tags(new_tag):
     If the tags are the same then an exception is raised. Returns 1 if the tags are distinct.
     """
 
-    # fetch kubeconfig file. Convert to a string for kubernetes client compatibility
-    kubeconfig = str(SCRIPT_PATH.joinpath("rendered", "kubeconfig.yaml"))
-
     # fetch the current lm-pod deployment info
-    locust_deployment = kubernetes_deploy.get_deployment("lm-pod", kubeconfig)
+    locust_deployment = kubernetes_deploy.get_deployment("lm-pod")
 
     # parse the image tag from the container
     image = locust_deployment.spec.template.spec.containers[0].image


### PR DESCRIPTION
Fix for issue 176500424.

`compare_tags` now respects the kubeconfig set in prior commands.

I'm also sneaking in an output formatting improvement for the setup command that was bugging me.