### PR TITLE
Unit tests for setup command [176804300]

### DIFF
--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -218,17 +218,7 @@ def test_main_set_k8s_context(mocker):
 
 def test_main_deploy_looker_secret(mocker):
 
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
+    parent_mock = mocker.Mock()
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -238,33 +228,27 @@ def test_main_deploy_looker_secret(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
+    context_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    deploy_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+
+    parent_mock.attach_mock(context_mock, "context_mock")
+    parent_mock.attach_mock(deploy_mock, "deploy_mock")
+
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert read_context == 1
-    nuke_utils.deploy_looker_secret.assert_called_with(MOCK_USER_CONFIG)
+    expected_call_order = [mocker.call.context_mock(MOCK_USER_CONFIG), mocker.call.deploy_mock(MOCK_USER_CONFIG)]
+    assert parent_mock.mock_calls == expected_call_order
 
 
 def test_main_deploy_oauth_secret_external(mocker):
 
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
+    parent_mock = mocker.Mock()
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -274,33 +258,25 @@ def test_main_deploy_oauth_secret_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
+    context_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    deploy_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+
+    parent_mock.attach_mock(context_mock, "context_mock")
+    parent_mock.attach_mock(deploy_mock, "deploy_mock")
+
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert read_context == 1
-    nuke_utils.deploy_oauth_secret.assert_called_with(MOCK_USER_CONFIG)
+    expected_call_order = [mocker.call.context_mock(MOCK_USER_CONFIG), mocker.call.deploy_mock(MOCK_USER_CONFIG)]
+    assert parent_mock.mock_calls == expected_call_order
 
 
 def test_main_deploy_oauth_secret_no_external(mocker):
-
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -310,9 +286,9 @@ def test_main_deploy_oauth_secret_no_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret", side_effect=read_context)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
@@ -324,17 +300,7 @@ def test_main_deploy_oauth_secret_no_external(mocker):
 
 def test_main_deploy_external(mocker):
 
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
+    parent_mock = mocker.Mock()
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -344,33 +310,25 @@ def test_main_deploy_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    context_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    deploy_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+
+    parent_mock.attach_mock(context_mock, "context_mock")
+    parent_mock.attach_mock(deploy_mock, "deploy_mock")
 
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert read_context == 1
-    nuke_utils.deploy_external.assert_called_with()
+    expected_call_order = [mocker.call.context_mock(MOCK_USER_CONFIG), mocker.call.deploy_mock()]
+    assert parent_mock.mock_calls == expected_call_order
 
 
 def test_main_deploy_external_no_external(mocker):
-
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -380,10 +338,10 @@ def test_main_deploy_external_no_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external", side_effect=read_context)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
@@ -395,17 +353,7 @@ def test_main_deploy_external_no_external(mocker):
 
 def test_main_deploy_locust(mocker):
 
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
+    parent_mock = mocker.Mock()
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -415,33 +363,27 @@ def test_main_deploy_locust(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    context_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    deploy_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+
+    parent_mock.attach_mock(context_mock, "context_mock")
+    parent_mock.attach_mock(deploy_mock, "deploy_mock")
 
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert read_context == 1
-    nuke_utils.deploy_locust.assert_called_with()
+    expected_call_order = [mocker.call.context_mock(MOCK_USER_CONFIG), mocker.call.deploy_mock()]
+    assert parent_mock.mock_calls == expected_call_order
 
 
 def test_main_deploy_secondary(mocker):
 
-    set_context_called = 0
-    read_context = 0
-
-    def context_called(*args, **kwargs):
-        nonlocal set_context_called
-        set_context_called = 1
-
-    def read_context(*args, **kwargs):
-        nonlocal set_context_called
-        nonlocal read_context
-        read_context = set_context_called
+    parent_mock = mocker.Mock()
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -451,15 +393,19 @@ def test_main_deploy_secondary(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary", side_effect=read_context)
+
+    context_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    deploy_mock = mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    parent_mock.attach_mock(context_mock, "context_mock")
+    parent_mock.attach_mock(deploy_mock, "deploy_mock")
 
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert read_context == 1
-    nuke_utils.deploy_secondary.assert_called_with()
+    expected_call_order = [mocker.call.context_mock(MOCK_USER_CONFIG), mocker.call.deploy_mock()]
+    assert parent_mock.mock_calls == expected_call_order

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -1,0 +1,426 @@
+from nuke_from_orbit.commands import setup_commands
+from nuke_from_orbit.utils import nuke_utils
+from pathlib import Path
+
+
+CONFIG_DIR = Path(__file__).parent.parent.joinpath("configs")
+MOCK_USER_CONFIG = {
+    "gcp_service_account_file": "mock_sa_file.json",
+    "loadtest_dns_domain": "mockdomain.com"
+}
+
+
+def test_main_set_variables(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    mock_config_path = CONFIG_DIR.joinpath("mock_config.yaml")
+
+    setup_commands.main(config_file="mock_config.yaml", external=False, persistence=True)
+
+    nuke_utils.set_variables.assert_called_with(mock_config_path, "v1", False)
+
+
+def test_main_run_threads_persistence_no_external(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=False, persistence=True)
+
+    nuke_utils.deploy_gke.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_test_container_image.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_persistent_disk.assert_called_with(MOCK_USER_CONFIG)
+    # deploy ip shouldn't be called in multithread
+    nuke_utils.deploy_ip_address.assert_not_called()
+
+
+def test_main_run_threads_no_persistence_no_external(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=False, persistence=False)
+
+    nuke_utils.deploy_gke.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_test_container_image.assert_called_with(MOCK_USER_CONFIG)
+    # deploy ip and persistent disk shouldn't be called in multithread
+    nuke_utils.deploy_ip_address.assert_not_called()
+    nuke_utils.deploy_persistent_disk.assert_not_called()
+
+
+def test_main_run_threads_persistence_external(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=True)
+
+    nuke_utils.deploy_gke.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_test_container_image.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_persistent_disk.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_ip_address.assert_called_with(MOCK_USER_CONFIG)
+
+
+def test_main_run_threads_no_persistence_external(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    nuke_utils.deploy_gke.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_test_container_image.assert_called_with(MOCK_USER_CONFIG)
+    nuke_utils.deploy_ip_address.assert_called_with(MOCK_USER_CONFIG)
+    # persistent disk shouldn't be called
+    nuke_utils.deploy_persistent_disk.assert_not_called()
+
+
+def test_main_collect_yaml_templates_call(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    nuke_utils.collect_kube_yaml_templates.assert_called_with(True)
+
+
+def test_main_collect_yaml_templates_call_no_external(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=False, persistence=False)
+
+    nuke_utils.collect_kube_yaml_templates.assert_called_with(False)
+
+
+def test_main_render_templates(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates").return_value = ["mock_file_list"]
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    nuke_utils.render_kubernetes_templates.assert_called_with(MOCK_USER_CONFIG, ["mock_file_list"])
+
+
+def test_main_set_k8s_context(mocker):
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    nuke_utils.set_kubernetes_context.assert_called_with(MOCK_USER_CONFIG)
+
+
+def test_main_deploy_looker_secret(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_looker_secret.assert_called_with(MOCK_USER_CONFIG)
+
+
+def test_main_deploy_oauth_secret_external(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_oauth_secret.assert_called_with(MOCK_USER_CONFIG)
+
+
+def test_main_deploy_oauth_secret_no_external(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=False, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_oauth_secret.assert_not_called()
+
+
+def test_main_deploy_external(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_external.assert_called_with()
+
+
+def test_main_deploy_external_no_external(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=False, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_external.assert_not_called()
+
+
+def test_main_deploy_locust(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_locust.assert_called_with()
+
+
+def test_main_deploy_secondary(mocker):
+
+    set_context_called = 0
+
+    def context_called(*args, **kwargs):
+        nonlocal set_context_called
+        set_context_called = 1
+
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_test_container_image")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_persistent_disk")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.get_ip_address")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+
+    setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
+
+    # determine if context call occurs before deployment
+    assert set_context_called == 1
+    nuke_utils.deploy_secondary.assert_called_with()

--- a/tests/test_setup_command.py
+++ b/tests/test_setup_command.py
@@ -219,10 +219,16 @@ def test_main_set_k8s_context(mocker):
 def test_main_deploy_looker_secret(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -233,7 +239,7 @@ def test_main_deploy_looker_secret(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.collect_kube_yaml_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
@@ -242,17 +248,23 @@ def test_main_deploy_looker_secret(mocker):
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert set_context_called == 1
+    assert read_context == 1
     nuke_utils.deploy_looker_secret.assert_called_with(MOCK_USER_CONFIG)
 
 
 def test_main_deploy_oauth_secret_external(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -264,7 +276,7 @@ def test_main_deploy_oauth_secret_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
@@ -272,17 +284,23 @@ def test_main_deploy_oauth_secret_external(mocker):
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert set_context_called == 1
+    assert read_context == 1
     nuke_utils.deploy_oauth_secret.assert_called_with(MOCK_USER_CONFIG)
 
 
 def test_main_deploy_oauth_secret_no_external(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -294,25 +312,29 @@ def test_main_deploy_oauth_secret_no_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.render_kubernetes_templates")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
     setup_commands.main(config_file="mock_config.yaml", external=False, persistence=False)
 
-    # determine if context call occurs before deployment
-    assert set_context_called == 1
     nuke_utils.deploy_oauth_secret.assert_not_called()
 
 
 def test_main_deploy_external(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -325,24 +347,30 @@ def test_main_deploy_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert set_context_called == 1
+    assert read_context == 1
     nuke_utils.deploy_external.assert_called_with()
 
 
 def test_main_deploy_external_no_external(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -355,24 +383,29 @@ def test_main_deploy_external_no_external(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_kubernetes_context", side_effect=context_called)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
     setup_commands.main(config_file="mock_config.yaml", external=False, persistence=False)
 
     # determine if context call occurs before deployment
-    assert set_context_called == 1
     nuke_utils.deploy_external.assert_not_called()
 
 
 def test_main_deploy_locust(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -386,23 +419,29 @@ def test_main_deploy_locust(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_looker_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust", side_effect=read_context)
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
 
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert set_context_called == 1
+    assert read_context == 1
     nuke_utils.deploy_locust.assert_called_with()
 
 
 def test_main_deploy_secondary(mocker):
 
     set_context_called = 0
+    read_context = 0
 
     def context_called(*args, **kwargs):
         nonlocal set_context_called
         set_context_called = 1
+
+    def read_context(*args, **kwargs):
+        nonlocal set_context_called
+        nonlocal read_context
+        read_context = set_context_called
 
     mocker.patch("nuke_from_orbit.utils.nuke_utils.set_variables").return_value = MOCK_USER_CONFIG
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_gke")
@@ -417,10 +456,10 @@ def test_main_deploy_secondary(mocker):
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_oauth_secret")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_external")
     mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_locust")
-    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary")
+    mocker.patch("nuke_from_orbit.utils.nuke_utils.deploy_secondary", side_effect=read_context)
 
     setup_commands.main(config_file="mock_config.yaml", external=True, persistence=False)
 
     # determine if context call occurs before deployment
-    assert set_context_called == 1
+    assert read_context == 1
     nuke_utils.deploy_secondary.assert_called_with()


### PR DESCRIPTION
Adding unit tests for the setup_command module. 

The only complexity here is the way I'm testing that the kubernetes context gets set before the deployments are done. This is a necessary thing to check b/c a reported bug had to do with the wrong context being set at the wrong time. My solution was to mock the side effect of the set context function by incrementing a flag variable inside each relevant test function. Don't know if it's standard practice but it certainly works and prevents a dependency on setting external state.

@drewgillson you're on for FYI only.

@googlesharon this may be a pattern you can replicate if you write tests for the other commands